### PR TITLE
Fix poses message not having a timestamp

### DIFF
--- a/motion_capture_tracking/src/motion_capture_tracking_node.cpp
+++ b/motion_capture_tracking/src/motion_capture_tracking_node.cpp
@@ -288,7 +288,7 @@ int main(int argc, char **argv)
 
     if (transforms.size() > 0) {
       // publish poses
-      msgPointCloud.header.stamp = time;
+      msgPoses.header.stamp = time;
       msgPoses.poses.resize(transforms.size());
       for (size_t i = 0; i < transforms.size(); ++i) {
         msgPoses.poses[i].name = transforms[i].child_frame_id;


### PR DESCRIPTION
Added a fix for timestamp not being assigned to the published "\poses" message