### PR TITLE
WIP: optitrack: disable closed-source natnet by default and update libmoti…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/libmotioncapture"]
 	path = motion_capture_tracking/deps/libmotioncapture
-	url = https://github.com/IMRCLab/libmotioncapture.git
+	url = https://github.com/Lorite/libmotioncapture.git
 [submodule "deps/librigidbodytracker"]
 	path = motion_capture_tracking/deps/librigidbodytracker
 	url = https://github.com/IMRCLab/librigidbodytracker.git

--- a/README.md
+++ b/README.md
@@ -81,6 +81,25 @@ There are two possible backends.
 * "optitrack" uses the Direct Depacketizers option. This works on all platforms, but often has compatibility issues with untested Motive versions and doesn't support all features.
 * "optitrack_closed_source" uses the official SDK (version 4.1.0) (only available on x64 Linux; distributed as a binary library)
 
+Note for Ubuntu 22.04 / ROS 2 Humble users: recent NatNet binary updates can require newer
+`glibc`/`libstdc++` versions than what ships with Ubuntu 22.04 (for example unresolved
+`GLIBC_2.38` / `GLIBCXX_3.4.31` at link time). In this case, keep using the open-source
+`optitrack` backend. This repository's CMake defaults now force
+`LIBMOTIONCAPTURE_ENABLE_OPTITRACK_CLOSED_SOURCE=OFF` to avoid stale cache settings from
+re-enabling the incompatible precompiled `libNatNet.so`.
+
+The `optitrack` backend also accepts `interface_ip` (default `0.0.0.0`) to select the local
+network interface for NatNet traffic. If not set, the node listens on all interfaces.
+
+If you previously configured a build with the closed-source backend, clear the package build
+artifacts before rebuilding:
+
+```
+cd ros2_ws
+rm -rf build/motion_capture_tracking install/motion_capture_tracking log/latest_build
+colcon build --symlink-install --packages-select motion_capture_tracking
+```
+
 Make sure that you have the following settings in Motive:
 
 menu Edit/Settings/Streaming:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ re-enabling the incompatible precompiled `libNatNet.so`.
 The `optitrack` backend also accepts `interface_ip` (default `0.0.0.0`) to select the local
 network interface for NatNet traffic. If not set, the node listens on all interfaces.
 
+For NatNet 4.1+ streams with multiple assets enabled, `motion_capture_tracking` now parses
+asset model descriptions and maps asset rigid-body IDs to names. This prevents empty names on
+`/poses` when multiple rigid bodies/assets are active (for example camera assets). If Motive
+streams a rigid body ID without a matching model description, the backend now publishes a stable
+fallback name (`rigid_body_<id>`) instead of an empty string.
+
 If you previously configured a build with the closed-source backend, clear the package build
 artifacts before rebuilding:
 

--- a/motion_capture_tracking/CMakeLists.txt
+++ b/motion_capture_tracking/CMakeLists.txt
@@ -26,7 +26,9 @@ set(LIBMOTIONCAPTURE_BUILD_EXAMPLE OFF)
 
 set(LIBMOTIONCAPTURE_ENABLE_QUALISYS ON)
 set(LIBMOTIONCAPTURE_ENABLE_OPTITRACK ON)
-set(LIBMOTIONCAPTURE_ENABLE_OPTITRACK_CLOSED_SOURCE OFF)
+# Force the cache value so stale build directories do not re-enable
+# linking against a precompiled libNatNet.so with incompatible GLIBC/GLIBCXX.
+set(LIBMOTIONCAPTURE_ENABLE_OPTITRACK_CLOSED_SOURCE OFF CACHE BOOL "Enable Optitrack (Closed Source)" FORCE)
 set(LIBMOTIONCAPTURE_ENABLE_VICON ON)
 set(LIBMOTIONCAPTURE_ENABLE_VRPN ON)
 set(LIBMOTIONCAPTURE_ENABLE_FZMOTION ON)
@@ -72,8 +74,10 @@ target_compile_features(motion_capture_tracking_node PUBLIC c_std_99 cxx_std_17)
 install(TARGETS motion_capture_tracking_node
   DESTINATION lib/${PROJECT_NAME})
 
-# The precompiled libNatNet library is only available for x64 Linux
-if ((CMAKE_SYSTEM_NAME STREQUAL "Linux") AND (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64"))
+# The precompiled libNatNet library is only needed for the closed-source backend.
+if (LIBMOTIONCAPTURE_ENABLE_OPTITRACK_CLOSED_SOURCE AND
+    (CMAKE_SYSTEM_NAME STREQUAL "Linux") AND
+    (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64"))
   install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/deps/libmotioncapture/deps/NatNetSDKCrossplatform/lib/ubuntu/libNatNet.so
     DESTINATION lib/${PROJECT_NAME}

--- a/motion_capture_tracking/src/motion_capture_tracking_node.cpp
+++ b/motion_capture_tracking/src/motion_capture_tracking_node.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <future>
 #include <vector>
 #include <fmt/core.h>
 
@@ -93,7 +94,27 @@ int main(int argc, char **argv)
     }
   }
 
-  libmotioncapture::MotionCapture *mocap = libmotioncapture::MotionCapture::connect(motionCaptureType, cfg);
+  // Connect to the motion capture system in a separate thread so that SIGINT
+  // received while the blocking NatNet handshake is in progress is handled
+  // cleanly by the rclcpp signal handler (rclcpp::ok() → false → we exit).
+  libmotioncapture::MotionCapture *mocap = nullptr;
+  {
+    auto connect_future = std::async(std::launch::async, [&]() {
+      return libmotioncapture::MotionCapture::connect(motionCaptureType, cfg);
+    });
+    while (rclcpp::ok()) {
+      rclcpp::spin_some(node);
+      if (connect_future.wait_for(std::chrono::milliseconds(50)) ==
+          std::future_status::ready) {
+        mocap = connect_future.get();
+        break;
+      }
+    }
+    if (!mocap) {
+      RCLCPP_INFO(node->get_logger(), "Shutdown requested while connecting — exiting.");
+      return 0;
+    }
+  }
 
   // prepare point cloud publisher
   auto pubPointCloud = node->create_publisher<sensor_msgs::msg::PointCloud2>("pointCloud", 1);
@@ -206,8 +227,16 @@ int main(int argc, char **argv)
 
   for (size_t frameId = 0; rclcpp::ok(); ++frameId) {
 
-    // Get a frame
-    mocap->waitForNextFrame();
+    // Get a frame — boost::asio throws system_error when SIGINT interrupts the
+    // blocking UDP recv inside waitForNextFrame().  Catch and exit cleanly.
+    try {
+      mocap->waitForNextFrame();
+    } catch (const std::exception& e) {
+      if (!rclcpp::ok()) {
+        break;
+      }
+      throw;
+    }
     auto chrono_now = std::chrono::high_resolution_clock::now();
     auto time = node->now();
 

--- a/motion_capture_tracking/src/motion_capture_tracking_node.cpp
+++ b/motion_capture_tracking/src/motion_capture_tracking_node.cpp
@@ -59,6 +59,11 @@ int main(int argc, char **argv)
   auto node = rclcpp::Node::make_shared("motion_capture_tracking_node");
   node->declare_parameter<std::string>("type", "vicon");
   node->declare_parameter<std::string>("hostname", "localhost");
+  // Local address to bind the data socket and pin the multicast group join to.
+  // Required on multi-homed hosts in multicast mode: an unpinned (0.0.0.0) join
+  // sends the IGMP membership out the default-route interface, which may not be
+  // the one facing the mocap network, and the stream then never arrives.
+  node->declare_parameter<std::string>("interface_ip", "0.0.0.0");
   node->declare_parameter<std::string>("topics.frame_id", "world");
   node->declare_parameter<std::string>("topics.poses.qos.mode", "none");
   node->declare_parameter<double>("topics.poses.qos.deadline", 100.0);
@@ -85,6 +90,7 @@ int main(int argc, char **argv)
   // Make a new client
   std::map<std::string, std::string> cfg;
   cfg["hostname"] = motionCaptureHostname;
+  cfg["interface_ip"] = node->get_parameter("interface_ip").as_string();
 
   // if the mock type is selected, add the defined rigid bodies
   if (motionCaptureType == "mock") {

--- a/motion_capture_tracking/src/motion_capture_tracking_node.cpp
+++ b/motion_capture_tracking/src/motion_capture_tracking_node.cpp
@@ -1,5 +1,7 @@
+#include <atomic>
 #include <iostream>
-#include <future>
+#include <memory>
+#include <thread>
 #include <vector>
 #include <fmt/core.h>
 
@@ -94,27 +96,43 @@ int main(int argc, char **argv)
     }
   }
 
-  // Connect to the motion capture system in a separate thread so that SIGINT
-  // received while the blocking NatNet handshake is in progress is handled
-  // cleanly by the rclcpp signal handler (rclcpp::ok() → false → we exit).
-  libmotioncapture::MotionCapture *mocap = nullptr;
-  {
-    auto connect_future = std::async(std::launch::async, [&]() {
-      return libmotioncapture::MotionCapture::connect(motionCaptureType, cfg);
-    });
-    while (rclcpp::ok()) {
-      rclcpp::spin_some(node);
-      if (connect_future.wait_for(std::chrono::milliseconds(50)) ==
-          std::future_status::ready) {
-        mocap = connect_future.get();
-        break;
-      }
-    }
-    if (!mocap) {
-      RCLCPP_INFO(node->get_logger(), "Shutdown requested while connecting — exiting.");
-      return 0;
-    }
+  // Connect to the motion capture system on a separate thread so that SIGINT
+  // received while the blocking NatNet handshake is in progress kills the
+  // process promptly. Previously this used std::async, whose returned future's
+  // destructor blocks until the async task completes — turning Ctrl+C into a
+  // 400-second wait while the libmotioncapture handshake exhausted its retry
+  // budget. Using std::thread + detach() means we abandon the worker on
+  // shutdown; the process exits and the OS reaps the thread.
+  //
+  // The result handoff goes through a shared_ptr<atomic<...>> so a late
+  // completion from the abandoned worker has no stack reference to a
+  // destructor-unwound local.
+  auto mocap_atomic =
+      std::make_shared<std::atomic<libmotioncapture::MotionCapture *>>(nullptr);
+  auto connect_done = std::make_shared<std::atomic<bool>>(false);
+  std::thread connect_thread(
+      [mocap_atomic, connect_done, motionCaptureType, cfg]() {
+        auto *m = libmotioncapture::MotionCapture::connect(motionCaptureType, cfg);
+        mocap_atomic->store(m);
+        connect_done->store(true);
+      });
+
+  while (rclcpp::ok() && !connect_done->load()) {
+    rclcpp::spin_some(node);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
   }
+
+  libmotioncapture::MotionCapture *mocap = mocap_atomic->load();
+  if (!mocap) {
+    RCLCPP_INFO(node->get_logger(),
+                "Shutdown requested while connecting — exiting.");
+    // Detach so the future's-destructor block of the old std::async approach
+    // doesn't happen. The worker is stuck in the NatNet handshake; the OS
+    // will tear it down when the process exits.
+    connect_thread.detach();
+    return 0;
+  }
+  connect_thread.join();
 
   // prepare point cloud publisher
   auto pubPointCloud = node->create_publisher<sensor_msgs::msg::PointCloud2>("pointCloud", 1);


### PR DESCRIPTION
Please read the comment below as well :)

- This PR targets ros2 and includes:
  - CMake guard to force LIBMOTIONCAPTURE_ENABLE_OPTITRACK_CLOSED_SOURCE=OFF in cache.
  - Conditional install of libNatNet only when closed-source backend is enabled.
  - Safer OptiTrack model-def parsing to avoid segfaults on malformed/newer packets.
  - interface_ip-aware UDP bind behavior with safe fallback.
  - Submodule update of deps/libmotioncapture to commit 3f4d0087a4938c5353fdfcfb497bdecccdfec0f4.
- Scope note:
  - Includes NatNetSDKCrossplatform pointer bump only.
  - Explicitly excludes vrpn and vicon-datastream-sdk bumps.
- Validation:
  - colcon build --symlink-install --packages-select motion_capture_tracking passed.
- Related issue:
  - Fixes #29 